### PR TITLE
Add server database directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist-ssr
 # Wrangler (Cloudflare Workers)
 **/worker/.wrangler/
 packages/worker/.wrangler/
+
+# LiveStore database directories
+packages/server/kanban-board-store/


### PR DESCRIPTION
## Summary
- Adds `packages/server/kanban-board-store/` to .gitignore to prevent committing local LiveStore database files created when running the server

## Test plan
- [x] Verify the directory is no longer shown in `git status`
- [x] Confirm server still runs correctly with `pnpm dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `packages/server/kanban-board-store/` to `.gitignore` to exclude local LiveStore database files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88e009cc2ccb7930699c7f306c10a6782d959fb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->