### PR TITLE
Fix lint and TypeScript errors in CI

### DIFF
--- a/packages/web/src/livestore/schema.ts
+++ b/packages/web/src/livestore/schema.ts
@@ -88,7 +88,7 @@ const materializers = State.SQLite.materializers(events, {
   'v1.TaskMoved': ({ id, column, position, updatedAt }) => 
     tables.tasks.update({ column, position, updatedAt }).where({ id }),
   'v1.TaskUpdated': ({ id, title, description, updatedAt }) => {
-    const updates: any = { updatedAt }
+    const updates: { updatedAt: Date; title?: string; description?: string } = { updatedAt }
     if (title !== undefined) updates.title = title
     if (description !== undefined) updates.description = description
     return tables.tasks.update(updates).where({ id })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/web" },
+    { "path": "./packages/server" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Fixed ESLint error by replacing `any` type with explicit type in task update materializer
- Added root `tsconfig.json` for monorepo TypeScript project references to enable `tsc -b` command

## Changes
- `packages/web/src/livestore/schema.ts`: Changed `updates: any` to properly typed object
- `tsconfig.json`: Added root config with references to web and server packages

## Test plan
- [x] Lint passes locally
- [ ] CI lint job passes
- [ ] CI TypeScript check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces an `any` in task update materializer with a precise type and adds a root tsconfig with project references.
> 
> - **TypeScript**:
>   - Refine `updates` in `packages/web/src/livestore/schema.ts` from `any` to `{ updatedAt: Date; title?: string; description?: string }` in `v1.TaskUpdated` materializer.
> - **Build/Config**:
>   - Add root `tsconfig.json` with project references to `packages/web` and `packages/server`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 434faff7f6cfcbee231886919c4fd89b6d32ab70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->